### PR TITLE
Fix event data API handler imports

### DIFF
--- a/server/api/scanner/event-data/[eventId].get.ts
+++ b/server/api/scanner/event-data/[eventId].get.ts
@@ -1,4 +1,5 @@
 import { createClient } from '@supabase/supabase-js'
+import { defineEventHandler, getRouterParam, createError } from 'h3'
 
 export default defineEventHandler(async (event) => {
     const eventId = getRouterParam(event, 'eventId')


### PR DESCRIPTION
## Summary
- import required `h3` helpers in `event-data` API handler

## Testing
- `npm install`
- `npx tsc server/api/scanner/event-data/[eventId].get.ts --noEmit --skipLibCheck --target ES2015` *(fails: Cannot find module '@supabase/supabase-js')*

------
https://chatgpt.com/codex/tasks/task_e_68573ae0908c8327aeb02d5b7f093228