### PR TITLE
Update SSR redirect docs

### DIFF
--- a/docs/troubleshooting/deployment-configuration.md
+++ b/docs/troubleshooting/deployment-configuration.md
@@ -25,12 +25,15 @@
   to = "/event/index.html"
   status = 200
 
-# Redirect catch-all pour SSR
+# Fallback catch-all pour SSR
 [[redirects]]
   from = "/*"
-  to = "/.netlify/functions/server"
+  to = "/index.html"
   status = 200
 ```
+
+Ce fallback statique est essentiel: le rendu SSR de Nuxt s'appuie sur
+`index.html` pour démarrer correctement.
 
 ### Variables d'environnement Netlify
 


### PR DESCRIPTION
## Summary
- fix catch-all redirect documentation to match configuration
- clarify how the SSR server depends on the `index.html` fallback

## Testing
- `npm run build` *(fails: nuxt not found)*

------
https://chatgpt.com/codex/tasks/task_e_68573ae2ae548327a93e08e4be1e1cdc